### PR TITLE
Improve test coverage

### DIFF
--- a/Sources/Json/Json.swift
+++ b/Sources/Json/Json.swift
@@ -96,6 +96,7 @@ public struct Json {
                     newSubs.remove(at: 0)
                     var json = self[subs.first!]
                     json[newSubs] = newValue
+                    self[subs.first!] = json
             }
         }
     }

--- a/Sources/Json/Literals.swift
+++ b/Sources/Json/Literals.swift
@@ -45,6 +45,8 @@ extension Json: ExpressibleByArrayLiteral {
 
 extension Json: ExpressibleByDictionaryLiteral {
     public init(dictionaryLiteral elements: (String, Any)...) {
-        self.init { elements }
+        jsonData = Dictionary(elements, uniquingKeysWith: { (value1, value2) -> Any in
+            return value1
+        })
     }
 }

--- a/Sources/Request/Request/Request.swift
+++ b/Sources/Request/Request/Request.swift
@@ -58,7 +58,7 @@ public struct AnyRequest<ResponseType>/*: ObservableObject, Identifiable*/ where
         if !(params is CombinedParams) {
             self.params = CombinedParams(children: [params])
         } else {
-            self.params = builder() as! CombinedParams
+            self.params = params as! CombinedParams
         }
         self.response = Response()
     }

--- a/Tests/RequestTests/JsonTests.swift
+++ b/Tests/RequestTests/JsonTests.swift
@@ -54,17 +54,26 @@ class JsonTests: XCTestCase {
     }
     
     func testSubscripts() {
-        guard let json = try? Json(complexJson) else {
+        guard var json = try? Json(complexJson) else {
             XCTAssert(false)
             return
         }
         let subscripts: [JsonSubscript] = ["projects", 0, "codeCov"]
-        let _: [Any] = [
-            json.firstName,
-            json.projects[0],
-            json["projects", 0, "stars"],
-            json[subscripts]
-        ]
+        
+        json[] = 0
+
+        XCTAssertEqual(json["isEmployed"].bool, true)
+        json["isEmployed"] = false
+        XCTAssertEqual(json["isEmployed"].bool, false)
+
+        XCTAssertEqual(json["projects", 0, "stars"].int, 91)
+        json["projects", 0, "stars"] = 10
+        XCTAssertEqual(json["projects", 0, "stars"].int, 10)
+
+        XCTAssertEqual(json[subscripts].double, 0.98)
+        json[subscripts] = 0.49
+        XCTAssertEqual(json[subscripts].double, 0.49)
+
     }
     
     func testAccessors() {
@@ -84,6 +93,7 @@ class JsonTests: XCTestCase {
             json.projects[1].codeCov.double,
             json.projects[1].codeCov.doubleOptional as Any,
             json.projects[1].passing.boolOptional as Any,
+            json.projects[1].passing.bool as Any,
             json.value,
         ]
         XCTAssert(true)
@@ -95,8 +105,14 @@ class JsonTests: XCTestCase {
             return
         }
         json.firstName = "Cameron"
+        json.projects[0].stars = 100
         json.likes = ["Hello", "World"]
+        json.projects[1] = ["name" : "hello", "description" : "world"]
         XCTAssertEqual(json["firstName"].string, "Cameron")
+        XCTAssertEqual(json["projects"][0].stars.int, 100)
+        XCTAssertEqual(json["likes"][0].string, "Hello")
+        XCTAssertEqual(json["likes"][1].string, "World")
+        XCTAssertEqual(json["projects"][1]["name"].string, "hello")
     }
     
     func testStringify() {
@@ -119,6 +135,7 @@ class JsonTests: XCTestCase {
         ("measureParse", testMeasureParse),
         ("subscripts", testSubscripts),
         ("accessors", testAccessors),
+        ("set", testSet),
         ("stringify", testStringify),
         ("measureStringify", testMeasureStringify),
     ]

--- a/Tests/RequestTests/RequestTests.swift
+++ b/Tests/RequestTests/RequestTests.swift
@@ -31,10 +31,13 @@ final class RequestTests: XCTestCase {
     }
 
     func testRequestWithCondition() {
+        let condition = true
         performRequest(Request {
-            Url("https://jsonplaceholder.typicode.com/todos")
-            if true {
-                Method(.post)
+            if condition {
+                Url(protocol: .https, url: "jsonplaceholder.typicode.com/todos")
+            }
+            if !condition {
+                Url("invalidurl")
             }
         })
     }
@@ -50,6 +53,7 @@ final class RequestTests: XCTestCase {
                 "completed": true,
                 "userId": 3,
             ])
+            Body("{\"userId\" : 3,\"title\" : \"My Post\",\"completed\" : true}")
         })
     }
     
@@ -57,16 +61,37 @@ final class RequestTests: XCTestCase {
         performRequest(Request {
             Url("https://jsonplaceholder.typicode.com/todos")
             Method(.get)
-            Query(["userId":"1"])
+            Query(["userId":"1", "password": "2"])
+            Query([QueryParam("key", value: "value"), QueryParam("key2", value: "value2")])
         })
     }
-    
+
     func testComplexRequest() {
         performRequest(Request {
             Url("https://jsonplaceholder.typicode.com/todos")
             Method(.get)
             Query(["userId":"1"])
             Header.CacheControl(.noCache)
+        })
+    }
+
+    func testHeaders() {
+        performRequest(Request {
+            Url("https://jsonplaceholder.typicode.com/todos")
+            Header.Any(key: "Custom-Header", value: "value123")
+            Header.Accept(.json)
+            Header.Accept("text/html")
+            Header.Authorization(.basic(username: "carsonkatri", password: "password123"))
+            Header.Authorization(.bearer("authorizationToken"))
+            Header.CacheControl(.maxAge(1000))
+            Header.CacheControl(.maxStale(1000))
+            Header.CacheControl(.minFresh(1000))
+            Header.ContentLength(0)
+            Header.ContentType(.xml)
+            Header.Host("jsonplaceholder.typicode.com")
+            Header.Origin("www.example.com")
+            Header.Referer("redirectfrom.example.com")
+            Header.UserAgent(.firefoxMac)
         })
     }
     
@@ -101,10 +126,65 @@ final class RequestTests: XCTestCase {
             XCTAssert(true)
         }
     }
-    
+
+    func testString() {
+        let expectation = self.expectation(description: #function)
+        var response: String? = nil
+        var error: Data? = nil
+
+        _ = Request {
+            Url("https://jsonplaceholder.typicode.com/todos")
+        }
+        .onError { err in
+            error = err.error
+            expectation.fulfill()
+        }
+        .onString { result in
+            response = result
+            expectation.fulfill()
+        }
+        .call()
+        waitForExpectations(timeout: 10000)
+        if error != nil {
+            XCTAssert(false)
+        } else if response != nil {
+            XCTAssert(true)
+        }
+    }
+
+    func testJson() {
+        let expectation = self.expectation(description: #function)
+        var response: Json? = nil
+        var error: Data? = nil
+
+        _ = Request {
+            Url("https://jsonplaceholder.typicode.com/todos")
+        }
+        .onError { err in
+            error = err.error
+            expectation.fulfill()
+        }
+        .onJson { result in
+            response = result
+            expectation.fulfill()
+        }
+        .call()
+        waitForExpectations(timeout: 10000)
+        if error != nil {
+            XCTAssert(false)
+        } else if let response = response, response.count > 0 {
+            XCTAssert(true)
+        }
+    }
+
     func testRequestGroup() {
         let expectation = self.expectation(description: #function)
         var loaded: Int = 0
+        var datas: Int = 0
+        var strings: Int = 0
+        var jsons: Int = 0
+        var errors: Int = 0
+        let numberOfResponses = 10
         RequestGroup {
             Request {
                 Url("https://jsonplaceholder.typicode.com/todos")
@@ -115,18 +195,51 @@ final class RequestTests: XCTestCase {
             Request {
                 Url("https://jsonplaceholder.typicode.com/todos/1")
             }
+            Request {
+                Url("invalidURL")
+            }
         }
         .onData { (index, data) in
             if data != nil {
                 loaded += 1
+                datas += 1
             }
-            if loaded >= 3 {
+            if loaded >= numberOfResponses {
                 expectation.fulfill()
             }
         }
+        .onString { (index, string) in
+            if string != nil {
+                loaded += 1
+                strings += 1
+            }
+            if loaded >= numberOfResponses {
+                expectation.fulfill()
+            }
+        }
+        .onJson { (index, json) in
+            if json != nil {
+                loaded += 1
+                jsons += 1
+            }
+            if loaded >= numberOfResponses {
+                expectation.fulfill()
+            }
+        }
+        .onError({ (index, error) in
+            loaded += 1
+            errors += 1
+            if loaded >= numberOfResponses {
+                expectation.fulfill()
+            }
+        })
         .call()
         waitForExpectations(timeout: 10000)
-        XCTAssertEqual(loaded, 3)
+        XCTAssertEqual(loaded, numberOfResponses)
+        XCTAssertEqual(datas, 3)
+        XCTAssertEqual(strings, 3)
+        XCTAssertEqual(jsons, 3)
+        XCTAssertEqual(errors, 1)
     }
     
     func testRequestChain() {
@@ -135,6 +248,7 @@ final class RequestTests: XCTestCase {
         RequestChain {
             Request.chained { (data, err) in
                 Url("https://jsonplaceholder.typicode.com/todos")
+                Method(.get)
             }
             Request.chained { (data, err) in
                 let json = try? Json(data[0]!)
@@ -143,6 +257,27 @@ final class RequestTests: XCTestCase {
         }
         .call { (data, errors) in
             if data.count > 1 {
+                success = true
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 10000)
+        XCTAssert(success)
+    }
+
+    func testRequestChainErrors() {
+        let expectation = self.expectation(description: #function)
+        var success = false
+        RequestChain {
+            Request.chained { (data, err) in
+                Url("invalidurl")
+            }
+            Request.chained { (data, err) in
+                Url("https://jsonplaceholder.typicode.com/thispagedoesnotexist")
+            }
+        }
+        .call { (data, errors) in
+            if errors.count == 2 {
                 success = true
             }
             expectation.fulfill()
@@ -199,9 +334,13 @@ final class RequestTests: XCTestCase {
         ("post", testPost),
         ("query", testQuery),
         ("complexRequest", testComplexRequest),
+        ("headers", testHeaders),
         ("onObject", testObject),
+        ("onString", testString),
+        ("onJson", testJson),
         ("requestGroup", testRequestGroup),
         ("requestChain", testRequestChain),
+        ("requestChainErrors", testRequestChainErrors),
         ("anyRequest", testAnyRequest),
         ("testError", testError),
     ]


### PR DESCRIPTION
This PR adds and modifies tests to improve test coverage. Additionally, two Json bugs which would cause the new tests to fail are fixed. Basically, what remains uncovered is SwiftUI code, fatalError lines, and lines I'm pretty sure are unreachable.

The second commit removes an unnecessary second call of the Request builder closure.
