### PR TITLE
Add 'update' methods, which allow for repeated calls to Requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,17 @@ RequestChain {
 }
 ```
 
+## Repeated Calls
+`.update` is used to run additional calls after the initial one. You can pass it either a number or a custom `Publisher`. You can also chain together multiple `.update`s. The two `.update`s in the following example are equivalent, so the end result is that the `Request` will be called once immediately and twice every 10 seconds thereafter.
+```swift
+Request {
+    Url("https://jsonplaceholder.typicode.com/todo")
+}
+.update(every: 10)
+.update(publisher: Timer.publish(every: 10, on: .main, in: .common).autoconnect())
+.call()
+```
+
 ## Json
 `swift-request` includes support for `Json`.
 `Json` is used as the response type in the `onJson` callback on a `Request` object.

--- a/Tests/RequestTests/RequestTests.swift
+++ b/Tests/RequestTests/RequestTests.swift
@@ -329,6 +329,24 @@ final class RequestTests: XCTestCase {
         XCTAssert(success)
     }
 
+    func testUpdate() {
+        let expectation = self.expectation(description: #function)
+        var numResponses = 0
+
+        Request {
+            Url("https://jsonplaceholder.typicode.com/todos")
+        }
+        .update(every: 1)
+        .onData { data in
+                numResponses += 1
+                if numResponses >= 3 {
+                    expectation.fulfill()
+                }
+        }
+        .call()
+        waitForExpectations(timeout: 10000)
+    }
+
     static var allTests = [
         ("simpleRequest", testSimpleRequest),
         ("post", testPost),
@@ -343,5 +361,6 @@ final class RequestTests: XCTestCase {
         ("requestChainErrors", testRequestChainErrors),
         ("anyRequest", testAnyRequest),
         ("testError", testError),
+        ("testUpdate", testUpdate),
     ]
 }


### PR DESCRIPTION
This PR adds functionality to Request which allows for the Request to be repeated after the initial call. An example use case is an automatically-updating RequestView.

The following SwiftUI view is an example of this. The RequestView will call the request to load the content once when the view loads. Thereafter, the view will automatically update every 10 seconds. The view will also be updated whenever the user taps the button.

```
let subject = PassthroughSubject<Void, Never>()

    struct ContentView: View {
        var body: some View {
            VStack {
                Button(action: {
                    subject.send()
                }, label: {
                    Text("Refresh")
                })
                RequestView (Request {
                    Url("https://worldtimeapi.org/api/ip.txt")
                }.update(publisher: subject).update(every: 10)) {data in
                    Text(String(decoding: data ?? Data(), as: UTF8.self))
                    Text("placeholder")
                }
            }
        }
    }
```