### PR TITLE
RequestError is now a type of Error

### DIFF
--- a/Sources/Request/Helpers/RequestError.swift
+++ b/Sources/Request/Helpers/RequestError.swift
@@ -8,7 +8,15 @@
 import Foundation
 
 /// An error returned by the `Request`
-public struct RequestError {
+public struct RequestError: Error {
     public let statusCode: Int
     public let error: Data?
+
+    public var localizedDescription: String {
+        guard let data = self.error else {
+            return "Error code: \(self.statusCode)"
+        }
+
+        return String(data: data, encoding: .utf8) ?? "Error code: \(self.statusCode)"
+    }
 }

--- a/Sources/Request/Request/Extra/RequestChain.swift
+++ b/Sources/Request/Request/Extra/RequestChain.swift
@@ -10,20 +10,20 @@ import Foundation
 public extension Request {
     /// Creates a `Request` to be used in a `RequestChain`
     ///
-    /// This `Request` takes `[Data?]` and `[RequestError?]` as parameters.
+    /// This `Request` takes `[Data?]` and `[Error?]` as parameters.
     /// These parameters contain the results of the previously called `Request`s
     ///
     ///     Request.chained { (data, err) in
     ///         Url("https://api.example.com/todos/\(Json(data[0]!)![0]["id"].int)")
     ///     }
-    static func chained(@RequestBuilder builder: @escaping ([Data?], [RequestError?]) -> RequestParam) -> ([Data?], [RequestError?]) -> RequestParam {
+    static func chained(@RequestBuilder builder: @escaping ([Data?], [Error?]) -> RequestParam) -> ([Data?], [Error?]) -> RequestParam {
         return builder
     }
 }
 
 @_functionBuilder
 public struct RequestChainBuilder {
-    public static func buildBlock(_ requests: (([Data?], [RequestError?]) -> RequestParam)...) -> [([Data?], [RequestError?]) -> RequestParam] {
+    public static func buildBlock(_ requests: (([Data?], [Error?]) -> RequestParam)...) -> [([Data?], [Error?]) -> RequestParam] {
         return requests
     }
 }
@@ -49,15 +49,15 @@ public struct RequestChainBuilder {
 ///
 /// - Precondition: You must have **at least 2** `Request`s in your chain, or the compiler will have a fit.
 public struct RequestChain {
-    private let requests: [([Data?], [RequestError?]) -> RequestParam]
+    private let requests: [([Data?], [Error?]) -> RequestParam]
     
-    public init(@RequestChainBuilder requests: () -> [([Data?], [RequestError?]) -> RequestParam]) {
+    public init(@RequestChainBuilder requests: () -> [([Data?], [Error?]) -> RequestParam]) {
         self.requests = requests()
     }
     
     /// Perform the `Request`s in the chain, and optionally respond with the data from each one when complete.
-    public func call(_ callback: @escaping ([Data?], [RequestError?]) -> Void = { (_, _) in }) {
-        func _call(_ index: Int, data: [Data?], errors: [RequestError?], callback: @escaping ([Data?], [RequestError?]) -> Void) {
+    public func call(_ callback: @escaping ([Data?], [Error?]) -> Void = { (_, _) in }) {
+        func _call(_ index: Int, data: [Data?], errors: [Error?], callback: @escaping ([Data?], [Error?]) -> Void) {
             var params = self.requests[index](data, errors)
             if !(params is CombinedParams) {
                 params = CombinedParams(children: [params])

--- a/Sources/Request/Request/Extra/RequestGroup.swift
+++ b/Sources/Request/Request/Extra/RequestGroup.swift
@@ -41,7 +41,7 @@ public class RequestGroup {
     private var onData: ((Int, Data?) -> Void)?
     private var onString: ((Int, String?) -> Void)?
     private var onJson: ((Int, Json?) -> Void)?
-    private var onError: ((Int, RequestError) -> Void)?
+    private var onError: ((Int, Error) -> Void)?
     
     public init(@RequestGroupBuilder requests: () -> [Request]) {
         self.requests = requests()
@@ -62,7 +62,7 @@ public class RequestGroup {
         return self
     }
     
-    public func onError(_ callback: @escaping ((Int, RequestError) -> Void)) -> RequestGroup {
+    public func onError(_ callback: @escaping ((Int, Error) -> Void)) -> RequestGroup {
         self.onError = callback
         return self
     }

--- a/Sources/Request/Request/Request.swift
+++ b/Sources/Request/Request/Request.swift
@@ -50,7 +50,7 @@ public struct AnyRequest<ResponseType>/*: ObservableObject, Identifiable*/ where
     private var onString: ((String) -> Void)?
     private var onJson: ((Json) -> Void)?
     private var onObject: ((ResponseType) -> Void)?
-    private var onError: ((RequestError) -> Void)?
+    private var onError: ((Error) -> Void)?
     private var updatePublisher: AnyPublisher<Void,Never>?
     
     /*@Published*/ public var response: Response = Response()
@@ -75,7 +75,7 @@ public struct AnyRequest<ResponseType>/*: ObservableObject, Identifiable*/ where
                   onString: ((String) -> Void)?,
                   onJson: ((Json) -> Void)?,
                   onObject: ((ResponseType) -> Void)?,
-                  onError: ((RequestError) -> Void)?,
+                  onError: ((Error) -> Void)?,
                   updatePublisher: AnyPublisher<Void,Never>?) {
         self.params = params
         self.onData = onData
@@ -106,8 +106,8 @@ public struct AnyRequest<ResponseType>/*: ObservableObject, Identifiable*/ where
         Self.init(params: params, onData: onData, onString: onString, onJson: onJson, onObject: callback, onError: onError, updatePublisher: updatePublisher)
     }
     
-    /// Handle any `RequestError`s thrown by the `Request`
-    public func onError(_ callback: @escaping (RequestError) -> Void) -> Self {
+    /// Handle any `Error`s thrown by the `Request`
+    public func onError(_ callback: @escaping (Error) -> Void) -> Self {
         Self.init(params: params, onData: onData, onString: onString, onJson: onJson, onObject: onObject, onError: callback, updatePublisher: updatePublisher)
     }
     
@@ -174,7 +174,7 @@ public struct AnyRequest<ResponseType>/*: ObservableObject, Identifiable*/ where
                     }
                 }
             } else if let err = err, let onError = self.onError {
-                onError(RequestError(statusCode: -1, error: err.localizedDescription.data(using: .utf8)))
+                onError(err)
             }
             if let data = data {
                 if let onData = self.onData {

--- a/Tests/RequestTests/RequestTests.swift
+++ b/Tests/RequestTests/RequestTests.swift
@@ -6,10 +6,10 @@ final class RequestTests: XCTestCase {
     func performRequest(_ request: Request) {
         let expectation = self.expectation(description: #function)
         var response: Data? = nil
-        var error: Data? = nil
+        var error: Error? = nil
         request
         .onError { err in
-            error = err.error
+            error = err
             expectation.fulfill()
         }
         .onData { data in
@@ -105,13 +105,13 @@ final class RequestTests: XCTestCase {
         
         let expectation = self.expectation(description: #function)
         var response: [Todo]? = nil
-        var error: Data? = nil
+        var error: Error? = nil
 
         _ = AnyRequest<[Todo]> {
             Url("https://jsonplaceholder.typicode.com/todos")
         }
         .onError { err in
-            error = err.error
+            error = err
             expectation.fulfill()
         }
         .onObject { (todos: [Todo]?) in
@@ -130,13 +130,13 @@ final class RequestTests: XCTestCase {
     func testString() {
         let expectation = self.expectation(description: #function)
         var response: String? = nil
-        var error: Data? = nil
+        var error: Error? = nil
 
         _ = Request {
             Url("https://jsonplaceholder.typicode.com/todos")
         }
         .onError { err in
-            error = err.error
+            error = err
             expectation.fulfill()
         }
         .onString { result in
@@ -155,13 +155,13 @@ final class RequestTests: XCTestCase {
     func testJson() {
         let expectation = self.expectation(description: #function)
         var response: Json? = nil
-        var error: Data? = nil
+        var error: Error? = nil
 
         _ = Request {
             Url("https://jsonplaceholder.typicode.com/todos")
         }
         .onError { err in
-            error = err.error
+            error = err
             expectation.fulfill()
         }
         .onJson { result in


### PR DESCRIPTION
As mentioned in #30, the actual implementation of RequestError was removing other types of errors like the URLError, so the application cannot cast and verify what error occurred exactly. Now, the onError callback will have as a parameter a value of Error type and the application can cast it to RequestError or to URLError. 