### PR TITLE
Added Request.onStatusCode handler

### DIFF
--- a/Sources/Request/Request/Request+Combine.swift
+++ b/Sources/Request/Request/Request+Combine.swift
@@ -68,6 +68,11 @@ extension AnyRequest: Subscriber {
     public func receive(_ input: Input) -> Subscribers.Demand {
         if let res = input.response as? HTTPURLResponse {
             let statusCode = res.statusCode
+
+            if let onStatusCode = self.onStatusCode {
+                onStatusCode(statusCode)
+            }
+
             if statusCode < 200 || statusCode >= 300 {
                 if let onError = self.onError {
                     onError(RequestError(statusCode: statusCode, error: input.data))

--- a/Sources/Request/Request/Request.swift
+++ b/Sources/Request/Request/Request.swift
@@ -50,6 +50,7 @@ public struct AnyRequest<ResponseType> where ResponseType: Decodable {
     internal var onJson: ((Json) -> Void)?
     internal var onObject: ((ResponseType) -> Void)?
     internal var onError: ((Error) -> Void)?
+    internal var onStatusCode: ((Int) -> Void)?
     internal var updatePublisher: AnyPublisher<Void,Never>?
     
     public init(@RequestBuilder builder: () -> RequestParam) {
@@ -89,6 +90,11 @@ public struct AnyRequest<ResponseType> where ResponseType: Decodable {
     /// Handle any `Error`s thrown by the `Request`
     public func onError(_ callback: @escaping (Error) -> Void) -> Self {
         modify { $0.onError = callback }
+    }
+    
+    /// Sets the `onStatusCode` callback to be run whenever a `HTTPStatus` is retrieved
+    public func onStatusCode(_ callback: @escaping (Int) -> Void) -> Self {
+        modify { $0.onStatusCode = callback }
     }
     
     /// Performs the `Request`, and calls the `onData`, `onString`, `onJson`, and `onError` callbacks when appropriate.

--- a/Tests/RequestTests/RequestTests.swift
+++ b/Tests/RequestTests/RequestTests.swift
@@ -150,6 +150,39 @@ final class RequestTests: XCTestCase {
         })
     }
     
+    func testStatusCode() {
+        let expectation = self.expectation(description: #function)
+        let statusCodeExpectation = self.expectation(description: #function+"status")
+        var response: String? = nil
+        var error: Error? = nil
+        var statusCode: Int? = nil
+        
+        Request {
+            Url("https://jsonplaceholder.typicode.com/todos")
+        }
+        .onError { err in
+            error = err
+            expectation.fulfill()
+        }
+        .onString { result in
+            response = result
+            expectation.fulfill()
+        }
+        .onStatusCode { code in
+            statusCode = code
+            statusCodeExpectation.fulfill()
+        }
+        .call()
+        waitForExpectations(timeout: 10000)
+        if error != nil {
+            XCTAssert(false)
+        } else if statusCode != nil {
+            XCTAssert(true)
+        } else if response != nil {
+            XCTAssert(true)
+        }
+    }
+
     func testObject() {
         struct Todo: Decodable {
             let id: Int
@@ -676,6 +709,7 @@ final class RequestTests: XCTestCase {
         ("complexRequest", testComplexRequest),
         ("headers", testHeaders),
         ("onObject", testObject),
+        ("onStatusCode", testStatusCode),
         ("onString", testString),
         ("onJson", testJson),
         ("requestGroup", testRequestGroup),


### PR DESCRIPTION
Some APIs have on HTTP status code as return value. So it will be useful to access that status code on demand