### PR TITLE
Make adding auth headers after init easier.

### DIFF
--- a/Sources/Request/Request/Request.swift
+++ b/Sources/Request/Request/Request.swift
@@ -155,5 +155,21 @@ extension AnyRequest: Equatable {
         let rhsSession = rhs.buildSession()
         return lhsSession.configuration == rhsSession.configuration && lhsSession.request == rhsSession.request
     }
+    
+    public func prettyJson() -> String {
+        
+        
+        let session = self.buildSession()
+        let request = session.request
+        let conf = session.configuration
+        return """
+               \(request.httpMethod) \(request.url?.absoluteString ?? "")
+               Headers: \(request.allHTTPHeaderFields)
+               Body: \(request.httpBody)
+               Config: \(conf)
+               """
+        
+    }
+
 }
 

--- a/Sources/Request/Request/Request.swift
+++ b/Sources/Request/Request/Request.swift
@@ -61,7 +61,7 @@ public struct AnyRequest<ResponseType> where ResponseType: Decodable {
         self.rootParam = rootParam
     }
     
-    public func modify(_ modify: (inout Self) -> Void) -> Self {
+    internal func modify(_ modify: (inout Self) -> Void) -> Self {
         var mutableSelf = self
         modify(&mutableSelf)
         return mutableSelf
@@ -97,8 +97,9 @@ public struct AnyRequest<ResponseType> where ResponseType: Decodable {
         modify { $0.onStatusCode = callback }
     }
     
-    public func withAuthorization(_ authorization: Auth) -> Self {
-        self
+    public mutating func withAuthorization(_ authorization: Auth) -> Self {
+        self.rootParam = CombinedParams(children: [Header.Authorization(authorization)])
+        return self
     }
     
     /// Performs the `Request`, and calls the `onData`, `onString`, `onJson`, and `onError` callbacks when appropriate.

--- a/Sources/Request/Request/Request.swift
+++ b/Sources/Request/Request/Request.swift
@@ -97,6 +97,7 @@ public struct AnyRequest<ResponseType> where ResponseType: Decodable {
         modify { $0.onStatusCode = callback }
     }
     
+    /// Modifies self to contain the procided Auth struct in its headers
     public mutating func withAuthorization(_ authorization: Auth) -> Self {
         self.rootParam = CombinedParams(children: [Header.Authorization(authorization),
                                                    rootParam])

--- a/Sources/Request/Request/Request.swift
+++ b/Sources/Request/Request/Request.swift
@@ -165,10 +165,30 @@ extension AnyRequest {
         let conf = session.configuration
         return """
                \(request.httpMethod) \(request.url?.absoluteString ?? "")
-               Headers: \(request.allHTTPHeaderFields)
-               Body: \(request.httpBody)
+               Headers: \(Json(request.allHTTPHeaderFields).stringified ?? "")
+               Body: \(request.httpBody?.prettyJSON() ?? "")
                Config: \(conf)
                """
         
+    }
+}
+
+extension Data {
+    func toString() -> String {
+        return String(data:self, encoding: .utf8) ?? ""
+    }
+    func prettyJSON() -> String {
+        do {
+            let json = try JSONSerialization.jsonObject(with: self, options: [])
+            let data = try JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
+            guard let jsonString = String(data: data, encoding: .utf8) else {
+                print("Inavlid data")
+                return ""
+            }
+            return jsonString
+        } catch {
+            print("Data+prettyJSON | Error: \(error.localizedDescription)")
+        }
+        return ""
     }
 }

--- a/Sources/Request/Request/Request.swift
+++ b/Sources/Request/Request/Request.swift
@@ -159,15 +159,24 @@ extension AnyRequest: Equatable {
 
 extension AnyRequest {
     public func prettyJson() -> String {
-    
-        let session = self.buildSession()
-        let request = session.request
-        let conf = session.configuration
+        
+         let session = self.buildSession()
+         let request = session.request
+         let conf = session.configuration
+        
+            guard  let method = request.httpMethod,
+                   let url = request.url,
+                   let headers = request.allHTTPHeaderFields,
+                   let jh = Json(headers).stringified,
+                   let body = request.httpBody
+            else { return ""}
+        
         return """
-               \(request.httpMethod) \(request.url?.absoluteString ?? "")
-               Headers: \(Json(request.allHTTPHeaderFields).stringified ?? "")
-               Body: \(request.httpBody?.prettyJSON() ?? "")
-               Config: \(conf)
+               \(method.uppercased()) \(url)
+               Headers: \(jh)
+               __________________________________
+               Body: \(body.prettyJSON())
+               ___________________________________
                """
         
     }

--- a/Sources/Request/Request/Request.swift
+++ b/Sources/Request/Request/Request.swift
@@ -149,6 +149,12 @@ public struct AnyRequest<ResponseType> where ResponseType: Decodable {
     }
 }
 
+extension AnyRequest: Identifiable {
+    public var id: String {
+        buildSession().request.url!.absoluteString
+    }
+}
+
 extension AnyRequest: Equatable {
     public static func == (lhs: AnyRequest<ResponseType>, rhs: AnyRequest<ResponseType>) -> Bool {
         let lhsSession = lhs.buildSession()

--- a/Sources/Request/Request/Request.swift
+++ b/Sources/Request/Request/Request.swift
@@ -177,11 +177,13 @@ extension AnyRequest {
         let body = request.httpBody ?? Data()
 
         return """
-               \(method.uppercased()) \(url)
+               Endpoint: \(method.uppercased()) \(url)
+               __________________________________
                Headers: \(jh)
                __________________________________
                Body: \(body.prettyJSON())
                ___________________________________
+               End Of Request.
                """
         
     }

--- a/Sources/Request/Request/Request.swift
+++ b/Sources/Request/Request/Request.swift
@@ -43,7 +43,7 @@ public typealias Request = AnyRequest<Data>
 public struct AnyRequest<ResponseType> where ResponseType: Decodable {
     public let combineIdentifier = CombineIdentifier()
 
-    private var rootParam: RequestParam
+    public var rootParam: RequestParam
     
     internal var onData: ((Data) -> Void)?
     internal var onString: ((String) -> Void)?

--- a/Sources/Request/Request/Request.swift
+++ b/Sources/Request/Request/Request.swift
@@ -155,10 +155,11 @@ extension AnyRequest: Equatable {
         let rhsSession = rhs.buildSession()
         return lhsSession.configuration == rhsSession.configuration && lhsSession.request == rhsSession.request
     }
-    
+}
+
+extension AnyRequest {
     public func prettyJson() -> String {
-        
-        
+    
         let session = self.buildSession()
         let request = session.request
         let conf = session.configuration
@@ -170,6 +171,4 @@ extension AnyRequest: Equatable {
                """
         
     }
-
 }
-

--- a/Sources/Request/Request/Request.swift
+++ b/Sources/Request/Request/Request.swift
@@ -168,15 +168,14 @@ extension AnyRequest {
         
          let session = self.buildSession()
          let request = session.request
-         let conf = session.configuration
         
             guard  let method = request.httpMethod,
                    let url = request.url,
                    let headers = request.allHTTPHeaderFields,
-                   let jh = Json(headers).stringified,
-                   let body = request.httpBody
-            else { return ""}
-        
+                   let jh = Json(headers).stringified
+            else { return " "}
+        let body = request.httpBody ?? Data()
+
         return """
                \(method.uppercased()) \(url)
                Headers: \(jh)

--- a/Sources/Request/Request/Request.swift
+++ b/Sources/Request/Request/Request.swift
@@ -166,17 +166,17 @@ extension AnyRequest: Equatable {
 extension AnyRequest {
     public func prettyJson() -> String {
         
-         let session = self.buildSession()
-         let request = session.request
-        
-            guard  let method = request.httpMethod,
-                   let url = request.url,
-                   let headers = request.allHTTPHeaderFields,
-                   let jh = Json(headers).stringified
-            else { return " "}
+        let session = self.buildSession()
+        let request = session.request
+        let method = request.httpMethod ?? "WTF"
+        let url = request.url?.absoluteString ?? ""
+        let headers = request.allHTTPHeaderFields
         let body = request.httpBody ?? Data()
+        let jh = Json(headers ?? [:]).stringified ?? "No Headers"
 
         return """
+               Beginning of Request.
+               ----------------------------------
                Endpoint: \(method.uppercased()) \(url)
                __________________________________
                Headers: \(jh)

--- a/Sources/Request/Request/Request.swift
+++ b/Sources/Request/Request/Request.swift
@@ -61,7 +61,7 @@ public struct AnyRequest<ResponseType> where ResponseType: Decodable {
         self.rootParam = rootParam
     }
     
-    internal func modify(_ modify: (inout Self) -> Void) -> Self {
+    public func modify(_ modify: (inout Self) -> Void) -> Self {
         var mutableSelf = self
         modify(&mutableSelf)
         return mutableSelf

--- a/Sources/Request/Request/Request.swift
+++ b/Sources/Request/Request/Request.swift
@@ -97,6 +97,10 @@ public struct AnyRequest<ResponseType> where ResponseType: Decodable {
         modify { $0.onStatusCode = callback }
     }
     
+    public func withAuthorization(_ authorization: Auth) -> Self {
+        self
+    }
+    
     /// Performs the `Request`, and calls the `onData`, `onString`, `onJson`, and `onError` callbacks when appropriate.
     public func call() {
         buildPublisher()

--- a/Sources/Request/Request/Request.swift
+++ b/Sources/Request/Request/Request.swift
@@ -43,7 +43,7 @@ public typealias Request = AnyRequest<Data>
 public struct AnyRequest<ResponseType> where ResponseType: Decodable {
     public let combineIdentifier = CombineIdentifier()
 
-    public var rootParam: RequestParam
+    internal var rootParam: RequestParam
     
     internal var onData: ((Data) -> Void)?
     internal var onString: ((String) -> Void)?
@@ -98,7 +98,8 @@ public struct AnyRequest<ResponseType> where ResponseType: Decodable {
     }
     
     public mutating func withAuthorization(_ authorization: Auth) -> Self {
-        self.rootParam = CombinedParams(children: [Header.Authorization(authorization)])
+        self.rootParam = CombinedParams(children: [Header.Authorization(authorization),
+                                                   rootParam])
         return self
     }
     

--- a/Sources/Request/Request/RequestParams/CombinedParams.swift
+++ b/Sources/Request/Request/RequestParams/CombinedParams.swift
@@ -7,14 +7,14 @@
 
 import Foundation
 
-internal struct CombinedParams: RequestParam, SessionParam {
-    fileprivate let children: [RequestParam]
+public struct CombinedParams: RequestParam, SessionParam {
+    public let children: [RequestParam]
 
     init(children: [RequestParam]) {
         self.children = children
     }
 
-    func buildParam(_ request: inout URLRequest) {
+    public func buildParam(_ request: inout URLRequest) {
         children
             .sorted { a, _ in (a is Url) }
             .filter { !($0 is SessionParam) || $0 is CombinedParams }
@@ -23,7 +23,7 @@ internal struct CombinedParams: RequestParam, SessionParam {
             }
     }
 
-    func buildConfiguration(_ configuration: URLSessionConfiguration) {
+    public func buildConfiguration(_ configuration: URLSessionConfiguration) {
         children
             .compactMap { $0 as? SessionParam }
             .forEach {


### PR DESCRIPTION
This is useful for me, so perhaps it is for others.
I want my auth info in once place, and my auth service will add the auth headers it knows about for
requests created by other view models, since they define those terms and not auth this allows better SRP adherence.

